### PR TITLE
fix: guard @results with the connection mutex (fiber-safety)

### DIFF
--- a/spec/client_spec.cr
+++ b/spec/client_spec.cr
@@ -1,0 +1,121 @@
+require "./helper"
+
+# A minimal in-memory duplex IO standing in for a TCP socket, so the client's
+# read fiber + request/response correlation can be exercised without a server.
+#
+# It is *reactive* like a real server: the scripted response is produced only
+# after the client has sent (flushed) its request, and is built from the actual
+# messageID the client emitted — so these specs don't care whether IDs start at
+# 0 or 1, and the read fiber can't race ahead of #write under -Dpreview_mt.
+class FakeSocket < IO
+  getter sent = IO::Memory.new
+  getter? closed = false
+
+  def initialize(&@responder : Int32 -> Bytes)
+    @incoming = IO::Memory.new
+    @request_sent = Channel(Nil).new(1)
+    @reads_opened = false
+  end
+
+  def read(slice : Bytes) : Int32
+    unless @reads_opened
+      @reads_opened = true
+      @request_sent.receive
+    end
+    @incoming.read(slice)
+  end
+
+  def write(slice : Bytes) : Nil
+    @sent.write(slice)
+  end
+
+  def flush
+    if @incoming.size.zero?
+      message_id = IO::Memory.new(@sent.to_slice).read_bytes(ASN1::BER).children[0].get_integer.to_i
+      @incoming.write @responder.call(message_id)
+      @incoming.rewind
+      @request_sent.send(nil)
+    end
+    self
+  end
+
+  def close
+    @closed = true
+  end
+end
+
+private def concat(*parts : Bytes) : Bytes
+  io = IO::Memory.new
+  parts.each { |part| io.write part }
+  io.to_slice
+end
+
+# LDAPMessage byte streams built with the library's own BER primitives, so the
+# fixtures stay in sync with the encoder.
+private def search_entry(id : Int32, dn : String, attrs : Hash(String, Array(String) | Array(Bytes)))
+  attr_seq = attrs.map do |key, values|
+    value_bers = values.map { |v| LDAP::BER.new.set_string(v.is_a?(Bytes) ? String.new(v) : v, LDAP::UniversalTags::OctetString) }
+    LDAP.sequence({
+      LDAP::BER.new.set_string(key, LDAP::UniversalTags::OctetString),
+      LDAP.set(value_bers),
+    })
+  end
+  op = LDAP.app_sequence({
+    LDAP::BER.new.set_string(dn, LDAP::UniversalTags::OctetString),
+    LDAP.sequence(attr_seq),
+  }, LDAP::Tag::SearchReturnedData)
+  LDAP.sequence({LDAP::BER.new.set_integer(id), op}).to_slice
+end
+
+private def search_done(id : Int32, code : Int32 = 0)
+  op = LDAP.app_sequence({
+    LDAP::BER.new.set_integer(code, LDAP::UniversalTags::Enumerated),
+    LDAP::BER.new.set_string("", LDAP::UniversalTags::OctetString),
+    LDAP::BER.new.set_string("", LDAP::UniversalTags::OctetString),
+  }, LDAP::Tag::SearchResult)
+  LDAP.sequence({LDAP::BER.new.set_integer(id), op}).to_slice
+end
+
+describe LDAP::Client do
+  describe "#search" do
+    it "accumulates multiple SearchResultEntry packets into one result set" do
+      socket = FakeSocket.new do |id|
+        concat(
+          search_entry(id, "uid=a,dc=example,dc=com", {"cn" => ["Alice"], "objectClass" => ["person", "top"]}),
+          search_entry(id, "uid=b,dc=example,dc=com", {"cn" => ["Bob"]}),
+          search_done(id),
+        )
+      end
+      client = LDAP::Client.new(socket)
+      results = client.search(base: "dc=example,dc=com", filter: "(objectClass=*)")
+
+      results.size.should eq(2)
+      results[0]["dn"].should eq(["uid=a,dc=example,dc=com"])
+      results[0]["cn"].should eq(["Alice"])
+      results[0]["objectClass"].should eq(["person", "top"])
+      results[1]["dn"].should eq(["uid=b,dc=example,dc=com"])
+      results[1]["cn"].should eq(["Bob"])
+    end
+
+    it "returns an empty array when the search yields no entries" do
+      socket = FakeSocket.new { |id| search_done(id) }
+      client = LDAP::Client.new(socket)
+      client.search(base: "dc=example,dc=com", filter: "(cn=nobody)").should eq([] of Hash(String, Array(String)))
+    end
+
+    # Documents current behavior: octet-string attribute values are carried
+    # verbatim. Binary values (objectGUID, userCertificate, ...) survive in the
+    # String and are recoverable via String#to_slice. (Typed Bytes accessors
+    # are a separate API concern.)
+    it "preserves the raw bytes of binary attribute values" do
+      guid = Bytes[0x00, 0xff, 0xfe, 0x80, 0x41, 0x00, 0xc3, 0x28]
+      socket = FakeSocket.new do |id|
+        concat(search_entry(id, "uid=a,dc=example,dc=com", {"objectGUID" => [guid]}), search_done(id))
+      end
+      client = LDAP::Client.new(socket)
+      results = client.search(base: "dc=example,dc=com")
+
+      results[0]["objectGUID"][0].to_slice.should eq(guid)
+    end
+  end
+end

--- a/src/ldap/client.cr
+++ b/src/ldap/client.cr
@@ -67,7 +67,7 @@ class LDAP::Client
 
   def search(*args, **opts)
     result = write(*@request.search(*args, **opts)).get
-    results = @results.delete(result.id) || [] of Response
+    results = @mutex.synchronize { @results.delete(result.id) } || [] of Response
 
     if result.tag.search_result?
       details = result.parse_result
@@ -87,7 +87,10 @@ class LDAP::Client
     when Tag::SearchResultReferral
       # TODO::
     when Tag::SearchReturnedData
-      @results[response.id] << response
+      # Guarded by the same mutex as @requests: the read fiber appends here
+      # while a caller fiber deletes in #search — without this they race the
+      # Hash under multi-threading (-Dpreview_mt).
+      @mutex.synchronize { @results[response.id] << response }
     else
       request = @mutex.synchronize { @requests.delete response.id }
       if request


### PR DESCRIPTION
Second of the **Tier 0** items from the 1.0 audit (#6), independent of #7.

## The bug

`LDAP::Client` correlates responses across two fibers. `@requests` (message-id → promise) is mutex-guarded — but `@results` (message-id → accumulated search entries) is not:

```crystal
# read fiber (process!)
when Tag::SearchReturnedData
  @results[response.id] << response     # insert (+ default-block create)

# caller fiber (#search)
results = @results.delete(result.id) || [] of Response   # delete
```

Under `-Dpreview_mt` these run on different threads with no synchronisation. A concurrent insert (which, via the Hash default block, may also create+assign the bucket) and delete can race the `Hash` and corrupt it. `@requests` was already guarded for precisely this reason; `@results` is the odd one out.

## The fix

Both `@results` accesses now take the same `@mutex`, restoring parity with `@requests`. One line each, no public API or behaviour change.

## Specs

The client had **no** unit-level coverage. This adds the first, via an in-memory duplex `FakeSocket`. It's *reactive* — it produces the scripted response only after the client flushes its request, and echoes the **actual messageID the client emitted**, like a real server. That keeps the specs independent of the ID-allocation scheme (so this PR doesn't depend on #7) and stable under `-Dpreview_mt`:

- `#search` accumulates multiple `SearchResultEntry` packets into one result set
- `#search` with no entries returns an empty array
- binary attribute values are carried verbatim (recoverable via `String#to_slice`)

```
11 examples, 0 failures   # crystal spec
11 examples, 0 failures   # crystal spec -Dpreview_mt (stable across repeated runs)
```

## Honest scope note

These specs **prove the search/`@results` accumulation path works** (previously untested) and exercise it under MT. They do **not** deterministically reproduce the data race itself — a race needs two concurrent searches with interleaved entry streams and only manifests probabilistically. The mutex is a correctness hardening for MT-safety parity with `@requests`, not a fix for an observable single-threaded failure. Flagging that plainly rather than overclaiming.

(Same pre-existing repo-wide `ameba`/format drift under current Crystal as noted on #7 — left untouched here too.)

Refs #6.
