### PR TITLE
fix: don't crash on wire values outside our enum tables (RFC 4511 result codes / op tags)

### DIFF
--- a/spec/client_spec.cr
+++ b/spec/client_spec.cr
@@ -103,6 +103,26 @@ describe LDAP::Client do
       client.search(base: "dc=example,dc=com", filter: "(cn=nobody)").should eq([] of Hash(String, Array(String)))
     end
 
+    # End-to-end consequence of tolerant tag decoding: a response carrying an
+    # unmodelled protocol-op tag must not crash the read fiber — it resolves the
+    # request and surfaces as a clean per-call error to the caller.
+    it "surfaces an unexpected response tag as a clean error, not a read-fiber crash" do
+      unknown_tag = 30
+      socket = FakeSocket.new do |id|
+        op = LDAP.app_sequence({
+          LDAP::BER.new.set_integer(0, LDAP::UniversalTags::Enumerated),
+          LDAP::BER.new.set_string("", LDAP::UniversalTags::OctetString),
+          LDAP::BER.new.set_string("", LDAP::UniversalTags::OctetString),
+        }, unknown_tag)
+        LDAP.sequence({LDAP::BER.new.set_integer(id), op}).to_slice
+      end
+      client = LDAP::Client.new(socket)
+
+      expect_raises(LDAP::Error, /unexpected response/) do
+        client.search(base: "dc=example,dc=com")
+      end
+    end
+
     # Documents current behavior: octet-string attribute values are carried
     # verbatim. Binary values (objectGUID, userCertificate, ...) survive in the
     # String and are recoverable via String#to_slice. (Typed Bytes accessors

--- a/spec/response_spec.cr
+++ b/spec/response_spec.cr
@@ -1,0 +1,59 @@
+require "./helper"
+
+# LDAPMessage { messageID, protocolOp } built from the library's own BER
+# helpers, so fixtures track the encoder.
+private def message(id : Int32, op : LDAP::BER) : LDAP::BER
+  LDAP.sequence({LDAP::BER.new.set_integer(id), op})
+end
+
+# A result-bearing protocol op: SEQUENCE { resultCode ENUMERATED, matchedDN, errorMessage }.
+# `tag` defaults to a known op tag so the Code path can be tested in isolation;
+# pass a raw Int to forge an unknown protocol-op tag.
+private def result_op(code : Int32, tag = LDAP::Tag::SearchResult) : LDAP::BER
+  LDAP.app_sequence({
+    LDAP::BER.new.set_integer(code, LDAP::UniversalTags::Enumerated),
+    LDAP::BER.new.set_string("", LDAP::UniversalTags::OctetString),
+    LDAP::BER.new.set_string("", LDAP::UniversalTags::OctetString),
+  }, tag)
+end
+
+describe LDAP::Response do
+  describe ".from_response" do
+    # A server can send a protocol-op tag we don't model; decoding it must not
+    # crash the read fiber with a bare ArgumentError.
+    it "preserves an unknown protocol-op tag instead of raising" do
+      response = LDAP::Response.from_response(message(1, result_op(0, tag: 30)))
+      response.tag.value.should eq(30)
+    end
+  end
+
+  describe "#parse_result" do
+    it "preserves an unknown result code instead of raising" do
+      response = LDAP::Response.from_response(message(1, result_op(123)))
+      response.parse_result[:result_code].value.should eq(123)
+    end
+
+    it "decodes loopDetect (54), completing the RFC 4511 result-code table" do
+      response = LDAP::Response.from_response(message(1, result_op(54)))
+      response.parse_result[:result_code].should eq(LDAP::Response::Code::LoopDetect)
+    end
+
+    it "still decodes a known result code" do
+      response = LDAP::Response.from_response(message(1, result_op(49)))
+      response.parse_result[:result_code].should eq(LDAP::Response::Code::InvalidCredentials)
+    end
+  end
+
+  describe "#result_message" do
+    it "renders a known code" do
+      LDAP::Response.new(LDAP::BER.new.set_integer(1), result_op(0))
+        .result_message(LDAP::Response::Code::InvalidCredentials.value)
+        .should eq("invalid credentials")
+    end
+
+    it "renders an unknown code without raising" do
+      response = LDAP::Response.new(LDAP::BER.new.set_integer(1), result_op(0))
+      response.result_message(123).should eq("123")
+    end
+  end
+end

--- a/src/ldap/response.cr
+++ b/src/ldap/response.cr
@@ -34,6 +34,7 @@ class LDAP::Response
     Busy                         = 51
     Unavailable                  = 52
     UnwillingToPerform           = 53
+    LoopDetect                   = 54
     NamingViolation              = 64
     ObjectClassViolation         = 65
     NotAllowedOnNonLeaf          = 66
@@ -49,7 +50,9 @@ class LDAP::Response
 
   def initialize(message_id, payload, @control = nil)
     @id = message_id.get_integer.to_i
-    @tag = LDAP::Tag.from_value(payload.tag_number)
+    # Tag.new (not from_value) so an unmodelled protocol-op tag is preserved
+    # rather than crashing the read fiber with a bare ArgumentError.
+    @tag = LDAP::Tag.new(payload.tag_number.to_i32)
     @payload = payload.children
   end
 
@@ -89,7 +92,7 @@ class LDAP::Response
     raise LDAP::Error.new("Invalid LDAP result size") unless sequence.size >= 3
 
     {
-      result_code:   Code.from_value(sequence[0].get_integer),
+      result_code:   Code.new(sequence[0].get_integer.to_i32!),
       matched_dn:    sequence[1].get_string,
       error_message: sequence[2].get_string,
     }
@@ -111,8 +114,6 @@ class LDAP::Response
   end
 
   def result_message(code : Int)
-    Code.from_value(code).to_s.underscore.gsub('_', ' ')
-  rescue e
-    "unknown result (#{code})"
+    Code.new(code.to_i32!).to_s.underscore.gsub('_', ' ')
   end
 end


### PR DESCRIPTION
First robustness item from the audit's Tier 2 (#6). Reviewed before opening (no Critical/Important findings).

## The bug

`Response` decoding turns two **server-supplied** values into enum members with `Enum.from_value`, which raises a bare `ArgumentError` (not an `LDAP::Error`) on anything outside the table — and it runs in the read fiber (`process!`), so a single unexpected value tears down the whole connection:

- `Tag.from_value(payload.tag_number)` (`response.cr` `Response#initialize`) — an unmodelled protocol-op tag.
- `Code.from_value(result_code)` (`response.cr` `#parse_result`) — a result code not in the enum.

The `Code` table was also missing one standard RFC 4511 Appendix A code, **`loopDetect (54)`** (the other gaps — 9, 15, 22-31, … — are reserved/unassigned), which made the second path easy to hit against a real directory.

## The fix

Switch both sites to **`Enum.new`**, which is the idiomatic non-lossy choice here: named members still resolve, an unknown value is preserved (`.value` keeps the integer, `.to_s` renders it) and it never raises. Add `LoopDetect = 54`. Align `#result_message` onto `Code.new` (its `rescue` is now dead).

Type detail: `get_integer` is `Int64`, so the code path uses `.to_i32!` (wrapping) to stay non-raising even on a garbage integer; `tag_number` is a `UInt8` bit_field (≤ 31), so the tag path uses `.to_i32` (cannot overflow).

Downstream this is safe and is the whole point: an unknown `Tag` falls through `parse_response`'s `case` to `else`, resolves the request, and the caller's `tag.search_result?`/`bind_result?` guard raises a clean `LDAP::Error("unexpected response: …")` — on the calling fiber, with the read fiber still alive.

## Specs (TDD)

- `response_spec` (new): unknown tag preserved, unknown result code preserved, `loopDetect` decodes, a known code still decodes, `result_message` for known/unknown.
- `client_spec`: end-to-end — an unexpected response tag surfaces as a clean per-call error instead of crashing the read fiber (verified RED without the fix: the old code rejects the request with the `ArgumentError` from a dead read fiber).

```
18 examples, 0 failures        # crystal spec
18 examples, 0 failures        # crystal spec -Dpreview_mt (stable across runs)
```

No public signature change. (Note: `#result_message`'s output for an *unknown* code changes from `"unknown result (N)"` to `"N"`, consistent with how `Code` now renders unknowns; the method has no in-tree callers.)

Refs #6.
