### PR TITLE
fix: bound the size of received messages (allocation DoS)

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -5,6 +5,7 @@ crystal: ">= 0.36.1"
 dependencies:
   bindata:
     github: spider-gazelle/bindata
+    version: ~> 3.0
   promise:
     github: spider-gazelle/promise
 

--- a/spec/client_spec.cr
+++ b/spec/client_spec.cr
@@ -138,4 +138,35 @@ describe LDAP::Client do
       results[0]["objectGUID"][0].to_slice.should eq(guid)
     end
   end
+
+  describe "max_message_size" do
+    # A hostile/buggy server can declare a huge length and force the read fiber
+    # to allocate (or read) far beyond any real message. The per-client cap makes
+    # bindata reject the frame before allocating; here a 1 KiB cap rejects a frame
+    # declaring 5000 bytes of content. (5000, not ~2 GiB, so the test is safe to
+    # run even against an unbounded read.)
+    it "rejects a message whose declared length exceeds the cap" do
+      # SEQUENCE, long-form length 0x1388 (5000), no payload follows.
+      socket = FakeSocket.new { |_id| Bytes[0x30, 0x82, 0x13, 0x88] }
+      client = LDAP::Client.new(socket, max_message_size: 1024)
+
+      expect_raises(ASN1::ContentTooLarge) do
+        client.search(base: "dc=example,dc=com")
+      end
+    end
+
+    # The dangerous case the cap must also stop: a small outer frame that smuggles
+    # a child declaring an oversized length. bindata propagates the cap into
+    # children, so it's rejected at the cap check — before any large allocation —
+    # while decoding the message.
+    it "rejects an oversized child smuggled inside a small frame" do
+      # SEQUENCE (len 6) { OCTET STRING declaring ~2 GiB }: outer fits the cap, child doesn't.
+      socket = FakeSocket.new { |_id| Bytes[0x30, 0x06, 0x04, 0x84, 0x7F, 0xFF, 0xFF, 0xFF] }
+      client = LDAP::Client.new(socket, max_message_size: 1024)
+
+      expect_raises(ASN1::ContentTooLarge) do
+        client.search(base: "dc=example,dc=com")
+      end
+    end
+  end
 end

--- a/src/ldap/client.cr
+++ b/src/ldap/client.cr
@@ -8,7 +8,11 @@ class LDAP::Client
 
   class AuthError < Error; end
 
-  def initialize(socket, tls_context : OpenSSL::SSL::Context::Client? = nil)
+  # *max_message_size* caps how many bytes the BER decoder will allocate or read
+  # for a single received message and its nested values, guarding against a
+  # hostile server forcing a huge allocation. Defaults to 16 MiB; `0` or a
+  # negative value disables the bound.
+  def initialize(socket, tls_context : OpenSSL::SSL::Context::Client? = nil, @max_message_size : Int32 = 16 * 1024 * 1024)
     @results = Hash(Int32, Array(Response)).new do |h, k|
       h[k] = [] of Response
     end
@@ -101,10 +105,20 @@ class LDAP::Client
     end
   end
 
+  # Read one LDAPMessage, capping how much the BER decoder will allocate/read so
+  # a hostile or buggy server can't force a huge allocation (see the
+  # *max_message_size* constructor option).
+  private def read_message(io : IO) : BER
+    message = BER.new
+    message.max_content_length = @max_message_size
+    message.read(io)
+    message
+  end
+
   protected def process!
     socket = @socket
     while !socket.closed?
-      data = socket.read_bytes(ASN1::BER)
+      data = read_message(socket)
       parse_response data
     end
   rescue IO::Error
@@ -137,7 +151,7 @@ class LDAP::Client
     socket.write @request.start_tls[1].to_slice
 
     # Check if the remote supports TLS
-    response = Response.from_response socket.read_bytes(ASN1::BER)
+    response = Response.from_response read_message(socket)
     raise TlsError.new("expected a start_tls result") unless response.tag.extended_response?
     result = response.parse_result[:result_code]
     raise TlsError.new("start_tls failed with: #{result}") unless result.success?


### PR DESCRIPTION
Tier 2 robustness from the audit (#6). Reviewed before opening (no Critical/Important findings); consumes the cap merged into bindata.

## The bug

The read fiber decoded each message with `socket.read_bytes(ASN1::BER)`. bindata's BER decoder trusts the **declared** length and allocates it *before* reading, so a hostile or buggy server could:
- declare a huge definite length (up to ~2 GiB) → `Bytes.new(huge)` in `process!`;
- send an unterminated **indefinite** length → unbounded read;
- smuggle an oversized **child** inside a tiny frame (a 50-byte message whose child declares 2 GiB) → amplification.

All three force a large allocation from a small network input — a memory-exhaustion DoS.

## The fix

bindata **v3.0** exposes a per-instance `max_content_length` cap that guards every allocation site **and propagates into `children`**. crystal-ldap consumes it:

- new `max_message_size` option on `Client#initialize` (default **16 MiB**, configurable per connection; `0`/negative disables the bound);
- a private `read_message` helper sets the cap on a fresh `BER` and reads through it;
- used at **both** decode sites — `process!` and `start_tls`.

An over-cap frame raises `ASN1::ContentTooLarge` **before** allocating; the read fiber's existing rescue rejects the in-flight request with it. (Folding that raw bindata error into a unified `LDAP::Error` hierarchy is deferred to the error-model phase.)

## Dependency

Requires the cap, so `shard.yml` now depends on `bindata ~> 3.0` (the released tag containing `max_content_length` + the consolidated `ASN1::ContentTooLarge`). The full suite (incl. `-Dpreview_mt`) is green on `bindata 3.0.0`.

## Specs (TDD)

Via the in-memory `FakeSocket`, both safe to run (the cap rejects at the check, before any large allocation):
- a 1 KiB cap rejects a frame declaring 5000 bytes of content;
- a 1 KiB cap rejects a small outer frame smuggling a child that declares ~2 GiB (locks in the child-propagation, the load-bearing invariant).

```
22 examples, 0 failures        # crystal spec
22 examples, 0 failures        # crystal spec -Dpreview_mt (stable across runs)
```

Non-breaking (the new option is optional with a default).

Refs #6.
