### PR TITLE
refactor: rich OperationError carrying the LDAP result code

### DIFF
--- a/spec/client_spec.cr
+++ b/spec/client_spec.cr
@@ -1,49 +1,5 @@
 require "./helper"
 
-# A minimal in-memory duplex IO standing in for a TCP socket, so the client's
-# read fiber + request/response correlation can be exercised without a server.
-#
-# It is *reactive* like a real server: the scripted response is produced only
-# after the client has sent (flushed) its request, and is built from the actual
-# messageID the client emitted — so these specs don't care whether IDs start at
-# 0 or 1, and the read fiber can't race ahead of #write under -Dpreview_mt.
-class FakeSocket < IO
-  getter sent = IO::Memory.new
-  getter? closed = false
-
-  def initialize(&@responder : Int32 -> Bytes)
-    @incoming = IO::Memory.new
-    @request_sent = Channel(Nil).new(1)
-    @reads_opened = false
-  end
-
-  def read(slice : Bytes) : Int32
-    unless @reads_opened
-      @reads_opened = true
-      @request_sent.receive
-    end
-    @incoming.read(slice)
-  end
-
-  def write(slice : Bytes) : Nil
-    @sent.write(slice)
-  end
-
-  def flush
-    if @incoming.size.zero?
-      message_id = IO::Memory.new(@sent.to_slice).read_bytes(ASN1::BER).children[0].get_integer.to_i
-      @incoming.write @responder.call(message_id)
-      @incoming.rewind
-      @request_sent.send(nil)
-    end
-    self
-  end
-
-  def close
-    @closed = true
-  end
-end
-
 private def concat(*parts : Bytes) : Bytes
   io = IO::Memory.new
   parts.each { |part| io.write part }

--- a/spec/helper.cr
+++ b/spec/helper.cr
@@ -1,2 +1,46 @@
 require "spec"
 require "../src/ldap"
+
+# A minimal in-memory duplex IO standing in for a TCP socket, so the client's
+# read fiber + request/response correlation can be exercised without a server.
+#
+# It is *reactive* like a real server: the scripted response is produced only
+# after the client has sent (flushed) its request, and is built from the actual
+# messageID the client emitted — so specs don't care whether IDs start at 0 or 1,
+# and the read fiber can't race ahead of #write under -Dpreview_mt.
+class FakeSocket < IO
+  getter sent = IO::Memory.new
+  getter? closed = false
+
+  def initialize(&@responder : Int32 -> Bytes)
+    @incoming = IO::Memory.new
+    @request_sent = Channel(Nil).new(1)
+    @reads_opened = false
+  end
+
+  def read(slice : Bytes) : Int32
+    unless @reads_opened
+      @reads_opened = true
+      @request_sent.receive
+    end
+    @incoming.read(slice)
+  end
+
+  def write(slice : Bytes) : Nil
+    @sent.write(slice)
+  end
+
+  def flush
+    if @incoming.size.zero?
+      message_id = IO::Memory.new(@sent.to_slice).read_bytes(ASN1::BER).children[0].get_integer.to_i
+      @incoming.write @responder.call(message_id)
+      @incoming.rewind
+      @request_sent.send(nil)
+    end
+    self
+  end
+
+  def close
+    @closed = true
+  end
+end

--- a/spec/operation_error_spec.cr
+++ b/spec/operation_error_spec.cr
@@ -1,0 +1,54 @@
+require "./helper"
+
+# A result-bearing LDAPMessage { messageID, [APPLICATION tag] { resultCode, matchedDN, errorMessage } }.
+private def result_message(id : Int32, tag : LDAP::Tag, code : Int32, dn = "", msg = "") : Bytes
+  op = LDAP.app_sequence({
+    LDAP::BER.new.set_integer(code, LDAP::UniversalTags::Enumerated),
+    LDAP::BER.new.set_string(dn, LDAP::UniversalTags::OctetString),
+    LDAP::BER.new.set_string(msg, LDAP::UniversalTags::OctetString),
+  }, tag)
+  LDAP.sequence({LDAP::BER.new.set_integer(id), op}).to_slice
+end
+
+describe LDAP::Client::OperationError do
+  it "carries the LDAP result fields and a composed message" do
+    err = LDAP::Client::OperationError.new("modify", LDAP::Response::Code::NoSuchObject, "ou=x", "no such entry")
+    err.result_code.should eq(LDAP::Response::Code::NoSuchObject)
+    err.matched_dn.should eq("ou=x")
+    err.error_message.should eq("no such entry")
+    err.message.should eq("modify failed with NoSuchObject: no such entry")
+  end
+
+  it "is the parent of AuthError" do
+    err = LDAP::Client::AuthError.new("bind", LDAP::Response::Code::InvalidCredentials, "", "bad creds")
+    err.should be_a(LDAP::Client::OperationError)
+    err.result_code.should eq(LDAP::Response::Code::InvalidCredentials)
+  end
+end
+
+describe LDAP::Client do
+  it "raises AuthError carrying the result code on a failed bind" do
+    socket = FakeSocket.new { |id| result_message(id, LDAP::Tag::BindResult, LDAP::Response::Code::InvalidCredentials.value, "", "bad creds") }
+    client = LDAP::Client.new(socket)
+    err = expect_raises(LDAP::Client::AuthError) { client.authenticate("cn=admin", "wrong") }
+    err.result_code.invalid_credentials?.should be_true
+    err.error_message.should eq("bad creds")
+  end
+
+  it "raises OperationError (not AuthError) on a failed search" do
+    socket = FakeSocket.new { |id| result_message(id, LDAP::Tag::SearchResult, LDAP::Response::Code::InsufficientAccessRights.value, "", "denied") }
+    client = LDAP::Client.new(socket)
+    err = expect_raises(LDAP::Client::OperationError) { client.search(base: "dc=x") }
+    err.should_not be_a(LDAP::Client::AuthError)
+    err.result_code.insufficient_access_rights?.should be_true
+  end
+
+  # SizeLimitExceeded/TimeLimitExceeded are "soft" search outcomes (partial
+  # results), still in SEARCH_SUCCESS — they must NOT raise. Pins that kept set
+  # before the later search-typing work revisits how partial results surface.
+  it "does not raise when a search hits the size limit" do
+    socket = FakeSocket.new { |id| result_message(id, LDAP::Tag::SearchResult, LDAP::Response::Code::SizeLimitExceeded.value) }
+    client = LDAP::Client.new(socket)
+    client.search(base: "dc=x").should eq([] of Hash(String, Array(String)))
+  end
+end

--- a/src/ldap/client.cr
+++ b/src/ldap/client.cr
@@ -6,7 +6,19 @@ require "../ldap"
 class LDAP::Client
   class TlsError < Error; end
 
-  class AuthError < Error; end
+  # Raised when an operation returns a non-success LDAP result code.
+  class OperationError < Error
+    getter result_code : Response::Code
+    getter matched_dn : String
+    getter error_message : String
+
+    def initialize(operation : String, @result_code : Response::Code, @matched_dn : String, @error_message : String)
+      super("#{operation} failed with #{@result_code}: #{@error_message}")
+    end
+  end
+
+  # Bind failure is an authentication concern callers often handle on its own.
+  class AuthError < OperationError; end
 
   def initialize(socket, tls_context : OpenSSL::SSL::Context::Client? = nil)
     @results = Hash(Int32, Array(Response)).new do |h, k|
@@ -55,7 +67,7 @@ class LDAP::Client
     if result.tag.bind_result?
       details = result.parse_bind_response
       result_code = details[:result_code]
-      raise AuthError.new("bind failed with #{result_code}: #{details[:error_message]}") unless result_code.success?
+      raise AuthError.new("bind", result_code, details[:matched_dn], details[:error_message]) unless result_code.success?
     else
       raise Error.new("unexpected response: #{result.tag}")
     end
@@ -72,7 +84,7 @@ class LDAP::Client
     if result.tag.search_result?
       details = result.parse_result
       result_code = details[:result_code]
-      raise AuthError.new("search failed with #{result_code}: #{details[:error_message]}") unless result_code.in?(Response::SEARCH_SUCCESS)
+      raise OperationError.new("search", result_code, details[:matched_dn], details[:error_message]) unless result_code.in?(Response::SEARCH_SUCCESS)
 
       results.map(&.parse_search_data)
     else


### PR DESCRIPTION
First PR of the operations / error-model work (#6), per the maintainer's 1.0 scope decision. Reviewed before opening (no Critical/Important findings).

## The problem

Operation failures were reported as bare-string exceptions, and `search` raised **`AuthError`** — an *authentication* type — on a search failure:

```crystal
raise AuthError.new("bind failed with #{result_code}: #{...}")    # authenticate
raise AuthError.new("search failed with #{result_code}: #{...}")  # search (wrong type!)
```

Callers could only string-match; they could never branch on the actual LDAP result code.

## The change

```crystal
class LDAP::Client
  class OperationError < LDAP::Error
    getter result_code : Response::Code
    getter matched_dn : String
    getter error_message : String
    # message: "<op> failed with <code>: <msg>" (unchanged)
  end
  class AuthError < OperationError; end   # bind stays a distinct, catchable type — now carrying the code
end
```

- `authenticate` raises the rich `AuthError`; `search` raises `OperationError` (not `AuthError`).
- `AuthError` is reparented under `OperationError`, so `rescue AuthError` **and** `rescue LDAP::Error` keep working; it now also carries `result_code`/`matched_dn`/`error_message`.
- One subclass only (`AuthError`) — no per-operation exception proliferation. `search` keeps its current `SEARCH_SUCCESS` set (partial-result/limit handling is deferred to the later search-typing work).

This is the foundation the upcoming write operations (Add/Delete/Modify/ModifyDN/Compare/Unbind) build on; a shared result-handling helper lands with them.

## Scope notes

- **Non-breaking** for `rescue AuthError`/`rescue LDAP::Error`; the message format is byte-for-byte unchanged. (Any external `AuthError.new("string")` caller would break — acceptable pre-1.0.)
- Folding `ASN1::ContentTooLarge` into the hierarchy waits on #11 (it touches `read_message`).
- The shared `FakeSocket` test harness moves to `spec/helper.cr` so every spec file compiles standalone.

## Specs

- `OperationError` carries the fields and composes the message.
- A failed bind raises `AuthError` with `result_code.invalid_credentials?`.
- A failed search raises `OperationError` (and **not** `AuthError`) with the code.
- A size-limit search still succeeds — pins the kept `SEARCH_SUCCESS` set before it's revisited.

```
25 examples, 0 failures        # crystal spec
25 examples, 0 failures        # crystal spec -Dpreview_mt (stable across runs)
```

Refs #6.
