### PR TITLE
feat: Add, Delete and Modify operations

### DIFF
--- a/spec/write_ops_spec.cr
+++ b/spec/write_ops_spec.cr
@@ -1,0 +1,157 @@
+require "./helper"
+
+# Decodes a built request's LDAPMessage back into {message_id, protocol-op BER}
+# so builder specs can assert structure without hand-computing every byte.
+private def decode_request(packet : LDAP::BER)
+  children = packet.children
+  {children[0].get_integer.to_i, children[1]}
+end
+
+# An LDAPResult-bearing response (Add/Delete/Modify/ModifyDN share this shape).
+private def result_response(id : Int32, tag : LDAP::Tag, code : Int32, dn = "", msg = "") : Bytes
+  op = LDAP.app_sequence({
+    LDAP::BER.new.set_integer(code, LDAP::UniversalTags::Enumerated),
+    LDAP::BER.new.set_string(dn, LDAP::UniversalTags::OctetString),
+    LDAP::BER.new.set_string(msg, LDAP::UniversalTags::OctetString),
+  }, tag)
+  LDAP.sequence({LDAP::BER.new.set_integer(id), op}).to_slice
+end
+
+describe LDAP::Request do
+  describe "#delete" do
+    it "encodes DelRequest as a primitive [APPLICATION 10] carrying the DN" do
+      # 30 09  02 01 01  4A 04 6F 75 3D 78
+      #  SEQ    msgID=1    [APP 10] primitive "ou=x"
+      _, packet = LDAP::Request.new.delete("ou=x")
+      packet.to_slice.should eq(Bytes[0x30, 0x09, 0x02, 0x01, 0x01, 0x4A, 0x04, 0x6F, 0x75, 0x3D, 0x78])
+    end
+  end
+
+  describe "#add" do
+    # Byte-exact anchor (computed by hand from RFC 4511 §4.7 / X.690), independent
+    # of the decoder — pins the constructed [APPLICATION 8] tag (0x68) and the
+    # SET-OF-values tag (0x31), which the decode-based check below cannot isolate.
+    it "encodes a minimal AddRequest to exact bytes" do
+      _, packet = LDAP::Request.new.add("o=x", {"cn" => ["A"]})
+      packet.to_slice.should eq(Bytes[
+        0x30, 0x17,                   # SEQUENCE (LDAPMessage), len 23
+        0x02, 0x01, 0x01,             #   messageID INTEGER 1
+        0x68, 0x12,                   #   [APPLICATION 8] constructed (AddRequest), len 18
+        0x04, 0x03, 0x6F, 0x3D, 0x78, #     entry "o=x"
+        0x30, 0x0B,                   #     attributes SEQUENCE OF, len 11
+        0x30, 0x09,                   #       attribute SEQUENCE, len 9
+        0x04, 0x02, 0x63, 0x6E,       #         type "cn"
+        0x31, 0x03,                   #         vals SET OF, len 3
+        0x04, 0x01, 0x41,             #           "A"
+      ])
+    end
+
+    it "encodes AddRequest [APPLICATION 8] with the entry DN and attribute list" do
+      _, packet = LDAP::Request.new.add("cn=a,dc=x", {"cn" => ["Alice"], "sn" => ["A", "B"]})
+      _, op = decode_request(packet)
+      op.tag_number.to_i.should eq(LDAP::Tag::AddRequest.value)
+
+      entry, attributes = op.children
+      entry.get_string.should eq("cn=a,dc=x")
+
+      attrs = attributes.children
+      attrs.size.should eq(2)
+      attrs[0].children[0].get_string.should eq("cn")
+      attrs[0].children[1].children.map(&.get_string).should eq(["Alice"])
+      attrs[1].children[0].get_string.should eq("sn")
+      attrs[1].children[1].children.map(&.get_string).should eq(["A", "B"])
+    end
+  end
+end
+
+describe LDAP::Modification do
+  it "builds add/delete/replace via named constructors" do
+    LDAP::Modification.add("objectClass", "person", "top").operation.add?.should be_true
+    LDAP::Modification.replace("mail", "a@b").values.should eq(["a@b"])
+
+    deletion = LDAP::Modification.delete("telephoneNumber")
+    deletion.operation.delete?.should be_true
+    deletion.type.should eq("telephoneNumber")
+    deletion.values.should be_empty
+  end
+
+  it "maps operations to the RFC 4511 §4.6 ENUMERATED values" do
+    LDAP::ModifyOperation::Add.value.should eq(0)
+    LDAP::ModifyOperation::Delete.value.should eq(1)
+    LDAP::ModifyOperation::Replace.value.should eq(2)
+  end
+end
+
+describe LDAP::Request do
+  describe "#modify" do
+    it "encodes ModifyRequest [APPLICATION 6] with the object DN and changes" do
+      _, packet = LDAP::Request.new.modify("cn=a,dc=x", [
+        LDAP::Modification.replace("mail", "a@b"),
+        LDAP::Modification.delete("phone"),
+      ])
+      _, op = decode_request(packet)
+      op.tag_number.to_i.should eq(LDAP::Tag::ModifyRequest.value)
+
+      object, changes = op.children
+      object.get_string.should eq("cn=a,dc=x")
+
+      change_list = changes.children
+      change_list.size.should eq(2)
+
+      operation, modification = change_list[0].children
+      operation.get_integer.should eq(LDAP::ModifyOperation::Replace.value)
+      modification.children[0].get_string.should eq("mail")
+      modification.children[1].children.map(&.get_string).should eq(["a@b"])
+
+      change_list[1].children[0].get_integer.should eq(LDAP::ModifyOperation::Delete.value)
+      change_list[1].children[1].children[1].children.should be_empty
+    end
+  end
+end
+
+describe LDAP::Client do
+  describe "#modify" do
+    it "returns self on a successful modify" do
+      socket = FakeSocket.new { |id| result_response(id, LDAP::Tag::ModifyResponse, 0) }
+      client = LDAP::Client.new(socket)
+      client.modify("cn=a,dc=x", [LDAP::Modification.replace("mail", "a@b")]).should be(client)
+    end
+
+    it "raises OperationError on a failed modify" do
+      socket = FakeSocket.new { |id| result_response(id, LDAP::Tag::ModifyResponse, LDAP::Response::Code::NoSuchObject.value, "", "missing") }
+      client = LDAP::Client.new(socket)
+      err = expect_raises(LDAP::Client::OperationError) { client.modify("cn=a,dc=x", [LDAP::Modification.delete("mail")]) }
+      err.result_code.no_such_object?.should be_true
+    end
+  end
+
+  describe "#delete" do
+    it "returns self on a successful delete" do
+      socket = FakeSocket.new { |id| result_response(id, LDAP::Tag::DeleteResponse, 0) }
+      client = LDAP::Client.new(socket)
+      client.delete("ou=x,dc=example,dc=com").should be(client)
+    end
+
+    it "raises OperationError on a failed delete" do
+      socket = FakeSocket.new { |id| result_response(id, LDAP::Tag::DeleteResponse, LDAP::Response::Code::NoSuchObject.value, "", "no such object") }
+      client = LDAP::Client.new(socket)
+      err = expect_raises(LDAP::Client::OperationError) { client.delete("ou=missing") }
+      err.result_code.no_such_object?.should be_true
+    end
+  end
+
+  describe "#add" do
+    it "returns self on a successful add" do
+      socket = FakeSocket.new { |id| result_response(id, LDAP::Tag::AddResponse, 0) }
+      client = LDAP::Client.new(socket)
+      client.add("cn=a,dc=x", {"cn" => ["Alice"]}).should be(client)
+    end
+
+    it "raises OperationError on a failed add" do
+      socket = FakeSocket.new { |id| result_response(id, LDAP::Tag::AddResponse, LDAP::Response::Code::EntryAlreadyExists.value, "", "exists") }
+      client = LDAP::Client.new(socket)
+      err = expect_raises(LDAP::Client::OperationError) { client.add("cn=a,dc=x", {"cn" => ["Alice"]}) }
+      err.result_code.entry_already_exists?.should be_true
+    end
+  end
+end

--- a/src/ldap.cr
+++ b/src/ldap.cr
@@ -105,6 +105,7 @@ module LDAP
   end
 end
 
+require "./ldap/modification"
 require "./ldap/request"
 require "./ldap/response"
 require "./ldap/client"

--- a/src/ldap/client.cr
+++ b/src/ldap/client.cr
@@ -96,6 +96,36 @@ class LDAP::Client
     end
   end
 
+  # https://tools.ietf.org/html/rfc4511#section-4.6
+  def modify(dn : String, changes : Enumerable(Modification)) : self
+    expect_result(@request.modify(dn, changes), Tag::ModifyResponse, "modify")
+    self
+  end
+
+  # https://tools.ietf.org/html/rfc4511#section-4.7
+  def add(dn : String, attributes : Hash(String, Array(String))) : self
+    expect_result(@request.add(dn, attributes), Tag::AddResponse, "add")
+    self
+  end
+
+  # https://tools.ietf.org/html/rfc4511#section-4.8
+  def delete(dn : String) : self
+    expect_result(@request.delete(dn), Tag::DeleteResponse, "delete")
+    self
+  end
+
+  # Sends a single-result operation, awaits its response, and raises
+  # OperationError on a non-success result code.
+  private def expect_result(request : {Int32, BER}, expected : Tag, operation : String) : Response
+    result = write(*request).get
+    raise Error.new("unexpected response: #{result.tag}") unless result.tag == expected
+    details = result.parse_result
+    unless details[:result_code].success?
+      raise OperationError.new(operation, details[:result_code], details[:matched_dn], details[:error_message])
+    end
+    result
+  end
+
   protected def parse_response(packet : BER)
     response = Response.from_response packet
     # Search results are returned in multiple packets

--- a/src/ldap/modification.cr
+++ b/src/ldap/modification.cr
@@ -1,0 +1,44 @@
+module LDAP
+  # A single change in a ModifyRequest. The enum values are the wire ENUMERATED
+  # encoding (RFC 4511 §4.6).
+  enum ModifyOperation
+    Add     = 0
+    Delete  = 1
+    Replace = 2
+  end
+
+  # One modification applied to an attribute by `LDAP::Client#modify`. Build via
+  # the named constructors:
+  #
+  #     LDAP::Modification.add("objectClass", "person")
+  #     LDAP::Modification.replace("mail", "alice@example.com")
+  #     LDAP::Modification.delete("telephoneNumber")   # whole attribute
+  struct Modification
+    getter operation : ModifyOperation
+    getter type : String
+    getter values : Array(String)
+
+    def initialize(@operation : ModifyOperation, @type : String, @values : Array(String))
+    end
+
+    def self.add(type : String, *values : String) : self
+      new(ModifyOperation::Add, type, values.to_a)
+    end
+
+    def self.delete(type : String) : self
+      new(ModifyOperation::Delete, type, [] of String)
+    end
+
+    def self.delete(type : String, *values : String) : self
+      new(ModifyOperation::Delete, type, values.to_a)
+    end
+
+    def self.replace(type : String) : self
+      new(ModifyOperation::Replace, type, [] of String)
+    end
+
+    def self.replace(type : String, *values : String) : self
+      new(ModifyOperation::Replace, type, values.to_a)
+    end
+  end
+end

--- a/src/ldap/request.cr
+++ b/src/ldap/request.cr
@@ -131,4 +131,42 @@ class LDAP::Request
       build(search_request)
     end
   end
+
+  # https://tools.ietf.org/html/rfc4511#section-4.6
+  def modify(dn : String, changes : Enumerable(Modification))
+    change_list = changes.map do |change|
+      LDAP.sequence({
+        BER.new.set_integer(change.operation.value, UniversalTags::Enumerated),
+        LDAP.sequence({
+          BER.new.set_string(change.type, UniversalTags::OctetString),
+          LDAP.set(change.values.map { |value| BER.new.set_string(value, UniversalTags::OctetString) }),
+        }),
+      })
+    end
+    build(LDAP.app_sequence({
+      BER.new.set_string(dn, UniversalTags::OctetString),
+      LDAP.sequence(change_list),
+    }, Tag::ModifyRequest))
+  end
+
+  # https://tools.ietf.org/html/rfc4511#section-4.7
+  def add(dn : String, attributes : Hash(String, Array(String)))
+    attribute_list = attributes.map do |type, values|
+      LDAP.sequence({
+        BER.new.set_string(type, UniversalTags::OctetString),
+        LDAP.set(values.map { |value| BER.new.set_string(value, UniversalTags::OctetString) }),
+      })
+    end
+    build(LDAP.app_sequence({
+      BER.new.set_string(dn, UniversalTags::OctetString),
+      LDAP.sequence(attribute_list),
+    }, Tag::AddRequest))
+  end
+
+  # https://tools.ietf.org/html/rfc4511#section-4.8
+  def delete(dn : String)
+    # DelRequest is [APPLICATION 10] LDAPDN — a primitive whose content is the
+    # DN itself, not a constructed sequence.
+    build(BER.new.set_string(dn, Tag::DeleteRequest.to_i, TagClass::Application))
+  end
 end


### PR DESCRIPTION
The first three write operations the maintainer scoped into 1.0 (#6), built on the `OperationError` model (#12). Reviewed before opening — verdict **Ready: Yes**, no Critical/Important.

## New public surface

```crystal
client.add(dn, {"cn" => ["Alice"], "objectClass" => ["person", "top"]})   # §4.7
client.delete(dn)                                                          # §4.8
client.modify(dn, [                                                        # §4.6
  LDAP::Modification.replace("mail", "alice@example.com"),
  LDAP::Modification.delete("telephoneNumber"),   # whole attribute
  LDAP::Modification.add("objectClass", "person"),
])
```

- All three return `self` (chainable, like `authenticate`) on success.
- All three go through a new private `expect_result` helper: write → await the matching `*Response` → raise `OperationError` (carrying `result_code`/`matched_dn`/`error_message`) on a non-success code. Consistent with how `authenticate`/`search` already drive an operation.

## Modify input types

`LDAP::Modification` (a `struct`) + `LDAP::ModifyOperation` enum whose values **are** the wire ENUMERATED (`Add=0, Delete=1, Replace=2`, RFC 4511 §4.6). `delete`/`replace` accept zero values (RFC: removes the attribute — a typed splat needs ≥1 in Crystal, so they get an explicit zero-arg overload); `add` requires ≥1.

## Wire format (verified against RFC 4511 §4.6–4.8 / X.690)

- **DelRequest** is the RFC's **primitive** `[APPLICATION 10]` — the DN is the content itself, not a sequence (`set_string(dn, 10, Application)` → tag `0x4A`).
- **AddRequest** `{ entry, attributes SEQ OF { type, vals SET OF } }`.
- **ModifyRequest** `{ object, changes SEQ OF { operation ENUMERATED, { type, vals SET OF } } }`.

Builders compose only the existing `LDAP.app_sequence`/`LDAP.sequence`/`LDAP.set`/`BER#set_*` helpers — no hand-assembled tag/length bytes.

## Specs (TDD)

- **Byte-exact** `DelRequest` and a **byte-exact minimal `AddRequest`** (the latter computed by hand from the RFC, independent of the decoder — it pins the constructed `0x68` and SET `0x31` tags that decode-based checks can't isolate).
- Decode-based structure checks for the richer Add/Modify builders.
- Per op: success → `self`; failure → `OperationError` with the right `result_code`.
- `Modification` constructors + their enum mapping.

```
39 examples, 0 failures        # crystal spec
39 examples, 0 failures        # crystal spec -Dpreview_mt
```

Next: ModifyDN / Compare / Unbind. Refs #6.
