### PR TITLE
feat: ModifyDN, Compare and Unbind operations

### DIFF
--- a/spec/write_ops_spec.cr
+++ b/spec/write_ops_spec.cr
@@ -155,3 +155,101 @@ describe LDAP::Client do
     end
   end
 end
+
+describe LDAP::Request do
+  describe "#modify_dn" do
+    it "encodes ModifyDNRequest [APPLICATION 12] with entry, newrdn and deleteoldrdn" do
+      # 30 14  02 01 01  6C 0F [04 04 "cn=a"][04 04 "cn=b"][01 01 FF]
+      _, packet = LDAP::Request.new.modify_dn("cn=a", "cn=b")
+      packet.to_slice.should eq(Bytes[
+        0x30, 0x14, 0x02, 0x01, 0x01,
+        0x6C, 0x0F,
+        0x04, 0x04, 0x63, 0x6E, 0x3D, 0x61, # entry "cn=a"
+        0x04, 0x04, 0x63, 0x6E, 0x3D, 0x62, # newrdn "cn=b"
+        0x01, 0x01, 0xFF,                   # deleteoldrdn TRUE
+      ])
+    end
+
+    it "appends newSuperior as a context [0] field when given" do
+      _, packet = LDAP::Request.new.modify_dn("cn=a,ou=x", "cn=a", delete_old_rdn: false, new_superior: "ou=y")
+      _, op = decode_request(packet)
+      op.tag_number.to_i.should eq(LDAP::Tag::ModifyRDNRequest.value)
+      fields = op.children
+      fields.size.should eq(4)
+      fields[2].get_boolean.should be_false
+      fields[3].tag_class.should eq(LDAP::TagClass::ContextSpecific)
+      fields[3].tag_number.to_i.should eq(0)
+      # context-specific tag, so read the raw payload (get_string requires universal)
+      String.new(fields[3].get_bytes).should eq("ou=y")
+    end
+  end
+
+  describe "#compare" do
+    it "encodes CompareRequest [APPLICATION 14] with entry and AVA" do
+      _, packet = LDAP::Request.new.compare("cn=a", "sn", "smith")
+      _, op = decode_request(packet)
+      op.tag_number.to_i.should eq(LDAP::Tag::CompareRequest.value)
+      entry, ava = op.children
+      entry.get_string.should eq("cn=a")
+      ava.children[0].get_string.should eq("sn")
+      ava.children[1].get_string.should eq("smith")
+    end
+  end
+
+  describe "#unbind" do
+    it "encodes UnbindRequest as [APPLICATION 2] NULL" do
+      # 30 05  02 01 01  42 00
+      _, packet = LDAP::Request.new.unbind
+      packet.to_slice.should eq(Bytes[0x30, 0x05, 0x02, 0x01, 0x01, 0x42, 0x00])
+    end
+  end
+end
+
+describe LDAP::Client do
+  describe "#modify_dn" do
+    it "returns self on a successful modify_dn" do
+      socket = FakeSocket.new { |id| result_response(id, LDAP::Tag::ModifyRDNResponse, 0) }
+      client = LDAP::Client.new(socket)
+      client.modify_dn("cn=a,dc=x", "cn=b").should be(client)
+    end
+
+    it "raises OperationError on a failed modify_dn" do
+      socket = FakeSocket.new { |id| result_response(id, LDAP::Tag::ModifyRDNResponse, LDAP::Response::Code::EntryAlreadyExists.value, "", "exists") }
+      client = LDAP::Client.new(socket)
+      err = expect_raises(LDAP::Client::OperationError) { client.modify_dn("cn=a,dc=x", "cn=b") }
+      err.result_code.entry_already_exists?.should be_true
+    end
+  end
+
+  describe "#compare" do
+    it "returns true on CompareTrue" do
+      socket = FakeSocket.new { |id| result_response(id, LDAP::Tag::CompareResponse, LDAP::Response::Code::CompareTrue.value) }
+      client = LDAP::Client.new(socket)
+      client.compare("cn=a,dc=x", "sn", "smith").should be_true
+    end
+
+    it "returns false on CompareFalse" do
+      socket = FakeSocket.new { |id| result_response(id, LDAP::Tag::CompareResponse, LDAP::Response::Code::CompareFalse.value) }
+      client = LDAP::Client.new(socket)
+      client.compare("cn=a,dc=x", "sn", "jones").should be_false
+    end
+
+    it "raises OperationError on a real compare error" do
+      socket = FakeSocket.new { |id| result_response(id, LDAP::Tag::CompareResponse, LDAP::Response::Code::NoSuchObject.value, "", "missing") }
+      client = LDAP::Client.new(socket)
+      err = expect_raises(LDAP::Client::OperationError) { client.compare("cn=missing", "sn", "x") }
+      err.result_code.no_such_object?.should be_true
+    end
+  end
+
+  describe "#unbind" do
+    it "writes an UnbindRequest and closes the connection" do
+      # Unbind has no response; the server sends nothing back.
+      socket = FakeSocket.new { |_id| Bytes.new(0) }
+      client = LDAP::Client.new(socket)
+      client.unbind.should be_nil
+      client.closed?.should be_true
+      socket.sent.to_slice.should eq(Bytes[0x30, 0x05, 0x02, 0x01, 0x01, 0x42, 0x00])
+    end
+  end
+end

--- a/src/ldap/client.cr
+++ b/src/ldap/client.cr
@@ -114,6 +114,41 @@ class LDAP::Client
     self
   end
 
+  # https://tools.ietf.org/html/rfc4511#section-4.9
+  def modify_dn(dn : String, new_rdn : String, delete_old_rdn : Bool = true, new_superior : String? = nil) : self
+    expect_result(@request.modify_dn(dn, new_rdn, delete_old_rdn, new_superior), Tag::ModifyRDNResponse, "modify_dn")
+    self
+  end
+
+  # https://tools.ietf.org/html/rfc4511#section-4.10
+  # Returns whether the entry's attribute holds the asserted value.
+  def compare(dn : String, attribute : String, value : String) : Bool
+    result = write(*@request.compare(dn, attribute, value)).get
+    raise Error.new("unexpected response: #{result.tag}") unless result.tag.compare_response?
+    details = result.parse_result
+    result_code = details[:result_code]
+    case result_code
+    when .compare_true?  then true
+    when .compare_false? then false
+    else
+      raise OperationError.new("compare", result_code, details[:matched_dn], details[:error_message])
+    end
+  end
+
+  # https://tools.ietf.org/html/rfc4511#section-4.3
+  # Sends an UnbindRequest (which has no response) and closes the connection.
+  def unbind : Nil
+    _, request = @request.unbind
+    @mutex.synchronize do
+      # Idempotent teardown: unlike #write, a closed socket is a no-op, not an error.
+      unless @socket.closed?
+        @socket.write_bytes request
+        @socket.flush
+      end
+    end
+    close
+  end
+
   # Sends a single-result operation, awaits its response, and raises
   # OperationError on a non-success result code.
   private def expect_result(request : {Int32, BER}, expected : Tag, operation : String) : Response

--- a/src/ldap/request.cr
+++ b/src/ldap/request.cr
@@ -169,4 +169,34 @@ class LDAP::Request
     # DN itself, not a constructed sequence.
     build(BER.new.set_string(dn, Tag::DeleteRequest.to_i, TagClass::Application))
   end
+
+  # https://tools.ietf.org/html/rfc4511#section-4.9
+  def modify_dn(dn : String, new_rdn : String, delete_old_rdn : Bool = true, new_superior : String? = nil)
+    fields = [
+      BER.new.set_string(dn, UniversalTags::OctetString),
+      BER.new.set_string(new_rdn, UniversalTags::OctetString),
+      BER.new.set_boolean(delete_old_rdn),
+    ]
+    # newSuperior is [0] LDAPDN OPTIONAL — a context-specific primitive.
+    fields << BER.new.set_string(new_superior, 0, TagClass::ContextSpecific) if new_superior
+    build(LDAP.app_sequence(fields, Tag::ModifyRDNRequest))
+  end
+
+  # https://tools.ietf.org/html/rfc4511#section-4.10
+  def compare(dn : String, attribute : String, value : String)
+    ava = LDAP.sequence({
+      BER.new.set_string(attribute, UniversalTags::OctetString),
+      BER.new.set_string(value, UniversalTags::OctetString),
+    })
+    build(LDAP.app_sequence({
+      BER.new.set_string(dn, UniversalTags::OctetString),
+      ava,
+    }, Tag::CompareRequest))
+  end
+
+  # https://tools.ietf.org/html/rfc4511#section-4.3
+  def unbind
+    # UnbindRequest is [APPLICATION 2] NULL — a primitive with no content.
+    build(BER.new.set_string("", Tag::UnbindRequest.to_i, TagClass::Application))
+  end
 end


### PR DESCRIPTION
Completes the write/control operation set for 1.0 (#6), on the same `OperationError` model. Reviewed before opening — wire encoding verified byte-exact against RFC 4511 §4.3 / §4.9 / §4.10.

## New public surface

```crystal
client.modify_dn(dn, new_rdn, delete_old_rdn = true, new_superior = nil)  # §4.9 → self
client.compare(dn, attribute, value) : Bool                              # §4.10
client.unbind                                                            # §4.3 → Nil
```

- **modify_dn** — ModifyDNRequest `[APPLICATION 12]`. `new_superior`, when given, is appended as the `[0]` context-specific primitive LDAPDN (omitted when nil).
- **compare** — CompareRequest `[APPLICATION 14]`. `CompareTrue`/`CompareFalse` are the *answer* (→ `true`/`false`), so compare does **not** go through `expect_result`; any other code raises `OperationError`.
- **unbind** — UnbindRequest `[APPLICATION 2] NULL`. No response: the request is written under the mutex, then the connection is closed. It does **not** register a promise (nothing to await), and a closed socket is an idempotent no-op. `close` is unchanged (no implicit unbind).

## Wire format (verified against RFC 4511 / X.690)

- ModifyDNRequest `0x6C` (app+constructed+12); `newSuperior` = `0x80` (context primitive `[0]`).
- CompareRequest `{ entry, AVA{ attributeDesc, assertionValue } }`.
- UnbindRequest `0x42` (app+primitive+2), zero-length content — the RFC's IMPLICIT `[APPLICATION 2] NULL`.

## Specs (TDD)

- Byte-exact ModifyDNRequest and UnbindRequest.
- Decode-based checks for the `[0]` newSuperior and the Compare AVA.
- compare true / false / error; modify_dn success / failure; unbind writes the NULL request and closes.

```
49 examples, 0 failures        # crystal spec
49 examples, 0 failures        # crystal spec -Dpreview_mt
crystal tool format --check    # clean
./bin/ameba                    # 17 inspected, 0 failures
```

With this, all of Bind/Search/StartTLS + Add/Delete/Modify/ModifyDN/Compare/Unbind are implemented. Refs #6.
