### PR TITLE
fix: surface the message-size cap as a typed LDAP error

### DIFF
--- a/spec/client_spec.cr
+++ b/spec/client_spec.cr
@@ -106,9 +106,11 @@ describe LDAP::Client do
       socket = FakeSocket.new { |_id| Bytes[0x30, 0x82, 0x13, 0x88] }
       client = LDAP::Client.new(socket, max_message_size: 1024)
 
-      expect_raises(ASN1::ContentTooLarge) do
+      # Surfaced as an LDAP-typed error, not a raw bindata ASN1::ContentTooLarge.
+      err = expect_raises(LDAP::Client::MessageTooLargeError) do
         client.search(base: "dc=example,dc=com")
       end
+      err.should be_a(LDAP::Error)
     end
 
     # The dangerous case the cap must also stop: a small outer frame that smuggles
@@ -120,7 +122,26 @@ describe LDAP::Client do
       socket = FakeSocket.new { |_id| Bytes[0x30, 0x06, 0x04, 0x84, 0x7F, 0xFF, 0xFF, 0xFF] }
       client = LDAP::Client.new(socket, max_message_size: 1024)
 
-      expect_raises(ASN1::ContentTooLarge) do
+      # Raised while decoding children (parse_response), still surfaced typed.
+      expect_raises(LDAP::Client::MessageTooLargeError) do
+        client.search(base: "dc=example,dc=com")
+      end
+    end
+
+    # A well-framed SearchResultEntry whose *attribute* declares an oversized
+    # length: only detected in parse_search_data (the caller fiber), which must
+    # also surface it typed.
+    it "surfaces a cap breach during search-data parsing as MessageTooLargeError" do
+      socket = FakeSocket.new do |id|
+        # SearchResultEntry { "dn", attributes SEQ { attribute SEQ declaring ~2 GiB } }
+        entry = Bytes[0x30, 0x11, 0x02, 0x01, id.to_u8, 0x64, 0x0C,
+          0x04, 0x02, 0x64, 0x6E,                         # objectName "dn"
+          0x30, 0x06, 0x30, 0x84, 0x7F, 0xFF, 0xFF, 0xFF] # attributes { bad attribute }
+        concat(entry, search_done(id))
+      end
+      client = LDAP::Client.new(socket, max_message_size: 1024)
+
+      expect_raises(LDAP::Client::MessageTooLargeError) do
         client.search(base: "dc=example,dc=com")
       end
     end

--- a/src/ldap/client.cr
+++ b/src/ldap/client.cr
@@ -6,6 +6,9 @@ require "../ldap"
 class LDAP::Client
   class TlsError < Error; end
 
+  # Raised when a received message exceeds `max_message_size` (see `#initialize`).
+  class MessageTooLargeError < Error; end
+
   # Raised when an operation returns a non-success LDAP result code.
   class OperationError < Error
     getter result_code : Response::Code
@@ -90,7 +93,9 @@ class LDAP::Client
       result_code = details[:result_code]
       raise OperationError.new("search", result_code, details[:matched_dn], details[:error_message]) unless result_code.in?(Response::SEARCH_SUCCESS)
 
-      results.map(&.parse_search_data)
+      # parse_search_data decodes nested children here (caller fiber); a cap
+      # breach must surface typed like the read-fiber paths.
+      wrap_too_large { results.map(&.parse_search_data) }
     else
       raise Error.new("unexpected response: #{result.tag}")
     end
@@ -151,10 +156,20 @@ class LDAP::Client
   # a hostile or buggy server can't force a huge allocation (see the
   # *max_message_size* constructor option).
   private def read_message(io : IO) : BER
-    message = BER.new
-    message.max_content_length = @max_message_size
-    message.read(io)
-    message
+    wrap_too_large do
+      message = BER.new
+      message.max_content_length = @max_message_size
+      message.read(io)
+      message
+    end
+  end
+
+  # Re-raises bindata's `ASN1::ContentTooLarge` (from the `max_message_size` cap)
+  # as an LDAP-typed error, so callers only ever see `LDAP::Error` subclasses.
+  private def wrap_too_large(&)
+    yield
+  rescue ex : ASN1::ContentTooLarge
+    raise MessageTooLargeError.new(ex.message)
   end
 
   protected def process!
@@ -166,13 +181,16 @@ class LDAP::Client
   rescue IO::Error
     @mutex.synchronize { close }
   rescue e
+    # A ContentTooLarge raised while decoding nested children surfaces here as an
+    # LDAP-typed error (the read_message rescue only covers the top-level frame).
+    error = e.is_a?(ASN1::ContentTooLarge) ? MessageTooLargeError.new(e.message) : e
     # A deliberate local #close (e.g. after a failed bind) unblocks the parked
     # read_bytes and surfaces as a decode error here — that is an expected
     # teardown, not a fault to log. Logging it raced the Log dispatcher at
     # shutdown and crashed with Channel::ClosedError (issue #2).
-    Log.error(exception: e) { e.message } unless @socket.closed?
+    Log.error(exception: error) { error.message } unless @socket.closed?
     @mutex.synchronize do
-      @requests.values.each(&.reject(e))
+      @requests.values.each(&.reject(error))
       @requests.clear
       close
     end


### PR DESCRIPTION
Small error-model completion (deferred from #11, now unblocked). Folds the message-size cap's exception into the `LDAP::Error` hierarchy.

## The gap

`max_message_size` (#11) made bindata reject oversized frames — but it raised bindata's `ASN1::ContentTooLarge` **straight to the caller**, leaking a raw dependency type through crystal-ldap's public error surface.

## The fix

A new `Client::MessageTooLargeError < LDAP::Error`, so callers only ever catch `LDAP::Error` and its subclasses. The cap can trip in **three** places — all now surface it typed:

1. **`read_message`** — the top-level frame (and the `start_tls` path);
2. **`process!`'s rescue** — a `ContentTooLarge` raised while decoding nested children in `parse_response` (read fiber), rejected to the caller typed;
3. **`#search`** — `parse_search_data` decodes deeper children in the caller fiber; wrapped via a shared `wrap_too_large` helper.

## Specs

- The two existing cap tests now assert `MessageTooLargeError` (and that it is-a `LDAP::Error`).
- A third pins path 3: a well-framed `SearchResultEntry` whose *attribute* declares an oversized length (only detected in `parse_search_data`).

```
40 examples, 0 failures        # crystal spec
40 examples, 0 failures        # crystal spec -Dpreview_mt
```

Refs #6.
